### PR TITLE
Fixed accidental caching of classSearch data

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,8 @@ jobs:
 #      uses: actions/setup-node@v1
 #      with:
 #        node-version: ${{ matrix.node-version }}
-    - run: npm install -g mocha rewire
+    - run: npm install -g mocha 
+    - run: npm install rewire
     - run: mocha
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,34 @@
+
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  repository_dispatch:
+  watch:
+    types: [started]
+    branches: [master]
+  pull_request:
+    branches: [ master ]
+    types: [opened, reopened]  
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install -g mocha
+    - run: mocha
+      env:
+        CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ jobs:
 #      with:
 #        node-version: ${{ matrix.node-version }}
     - run: npm install -g mocha 
-    - run: npm install rewire
+    - run: npm install rewire @schedulemaker/bannerjs@0.4.0
     - run: mocha
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ jobs:
 #      with:
 #        node-version: ${{ matrix.node-version }}
     - run: npm install -g mocha 
-    - run: npm install rewire @schedulemaker/bannerjs@0.4.0
+    - run: npm install @schedulemaker/bannerjs --registry https://npm.pkg.github.com
     - run: mocha
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    container: node:12
 
     strategy:
       matrix:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,16 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     container: node:12
 
-    strategy:
-      matrix:
-        node-version: [12.x]
+#    strategy:
+#      matrix:
+#        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+#    - name: Use Node.js ${{ matrix.node-version }}
+#      uses: actions/setup-node@v1
+#      with:
+#        node-version: ${{ matrix.node-version }}
     - run: npm install -g mocha rewire
     - run: mocha
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install -g mocha
+    - run: npm install -g mocha rewire
     - run: mocha
       env:
         CI: true

--- a/index/cache.js
+++ b/index/cache.js
@@ -12,6 +12,10 @@ if (typeof(fs) === 'undefined'){
     var readFile = promisify(fs.readFile);
 }
 
+if (typeof(excluded_methods) === 'undefined'){
+    var excluded_methods = process.env.EXCLUDED_METHODS.split(' ');
+}
+
 module.exports = {
     Banner: Banner,
     bannerObjs: {},
@@ -23,5 +27,6 @@ module.exports = {
     },
     dir: '/tmp',
     useTmp: false,
-    counter: 1
+    counter: 1,
+    excluded_methods: excluded_methods
 }

--- a/index/cache.js
+++ b/index/cache.js
@@ -1,7 +1,7 @@
 'use-strict'
 
 if (typeof(Banner) === 'undefined'){
-    var Banner = require('banner');
+    var Banner = require('@schedulemaker/bannerjs');
 }
 
 if (typeof(fs) === 'undefined'){

--- a/index/cache.js
+++ b/index/cache.js
@@ -1,7 +1,7 @@
 'use-strict'
 
 if (typeof(Banner) === 'undefined'){
-    var Banner = require('@schedulemaker/bannerjs');
+    var Banner = require('banner');
 }
 
 if (typeof(fs) === 'undefined'){

--- a/index/index.js
+++ b/index/index.js
@@ -74,10 +74,13 @@ async function requestData(school, term, method, params){
     if(typeof(cache.bannerObjs[school] === 'undefined')){
         cache.bannerObjs[school] = new cache.Banner(school);
     }
-    cache.useTmp ? await createTmpDirEntries(school, term) : createCacheEntries(school, term);
 
     //perform the request to Banner for the data
     let request = cache.bannerObjs[school][method](params);
+
+    if (!cache.excluded_methods.includes(method)){
+        cache.useTmp ? await createTmpDirEntries(school, term) : createCacheEntries(school, term);
+    }
 
     //put the data into the cache
     let obj = {
@@ -85,8 +88,11 @@ async function requestData(school, term, method, params){
         timestamp: Date.now() / 1000,
         data: await request
     }
-    cache.useTmp ? await cache.fs.writeFile(`${cache.dir}/${school}/${term}/${method}.json`, JSON.stringify(obj), 'utf8') 
-        : cache.bannerCache[school][term][method] = obj;
+    if (!cache.excluded_methods.includes(method)){
+        cache.useTmp ? await cache.fs.writeFile(`${cache.dir}/${school}/${term}/${method}.json`, JSON.stringify(obj), 'utf8') 
+            : cache.bannerCache[school][term][method] = obj;
+    }
+    
     //return the data
     return obj.data;
 }


### PR DESCRIPTION
Banner Proxy should no longer cache data returned from `classSearch` and instead perform a fresh request each time.

Fixes #4 